### PR TITLE
Take dependency on bears from latest PyPi release, not github

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license-files = ["LICENSE"]
 dependencies = [
     "autoenum",
     ## Pick up latest Git commit for bears package to ensure tests run:
-    "bears @ git+https://github.com/amazon-science/bears.git@main",
+    "bears",
     "requests",
     "pyyaml",
     "urllib3",


### PR DESCRIPTION
*Issue #, if available:* Release publish workflow is failing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
