### PR TITLE
Robust LLM Json Parsing logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__/
 
 .vscode/settings.json
 *.ipynb
+venv

--- a/src/fmcore/mapper/llm_response_json_mapper.py
+++ b/src/fmcore/mapper/llm_response_json_mapper.py
@@ -15,7 +15,7 @@ class LLMResponseJsonMapper(BaseMapper[str, List[Dict]]):
     Reference: https://pypi.org/project/json-repair/
     """
 
-    def normalize_json_response(json_str) -> List[Dict]:
+    def normalize_json_response(self, json_str: str) -> List[Dict]:
         """
         Normalize and repair JSON response into a list of dictionaries.
 

--- a/src/fmcore/mapper/llm_response_json_mapper.py
+++ b/src/fmcore/mapper/llm_response_json_mapper.py
@@ -37,16 +37,16 @@ class LLMResponseJsonMapper(BaseMapper[str, List[Dict]]):
             3. Invalid JSON -> returns empty list
         """
         response = json_repair.loads(json_str)
-        
+
         if isinstance(response, dict):
             # Wrap dict inside a list
             return [response]
-        
+
         if isinstance(response, list):
             # Filter list elements, keep only dicts
             filtered = [item for item in response if isinstance(item, dict)]
             return filtered
-        
+
         # If neither dict nor list, return empty list
         return []
 

--- a/src/fmcore/mapper/llm_response_json_mapper.py
+++ b/src/fmcore/mapper/llm_response_json_mapper.py
@@ -1,11 +1,10 @@
-import json
 import json_repair
-from typing import Dict
+from typing import Dict, List
 
-from fmcore.mapper.base_mapper import BaseMapper, I, O
+from fmcore.mapper.base_mapper import BaseMapper
 
 
-class LLMResponseJsonMapper(BaseMapper[str, Dict]):
+class LLMResponseJsonMapper(BaseMapper[str, List[Dict]]):
     """
     A mapper that processes LLM-generated responses by extracting and repairing JSON content.
 
@@ -16,29 +15,78 @@ class LLMResponseJsonMapper(BaseMapper[str, Dict]):
     Reference: https://pypi.org/project/json-repair/
     """
 
-    def map(self, data: str) -> Dict:
+    def normalize_json_response(json_str) -> List[Dict]:
         """
-        Convert the input string to a JSON dictionary.
+        Normalize and repair JSON response into a list of dictionaries.
+
+        This method takes a JSON string, attempts to repair any malformed JSON using json_repair,
+        and ensures the output is always a list of dictionaries. If the input is a single dictionary,
+        it will be wrapped in a list. If the input is a list, it will filter out non-dictionary items.
 
         Args:
-            data (str): The input string to convert
+            json_str (str): The JSON string to normalize and repair
 
         Returns:
-            Dict: The parsed JSON dictionary
+            List[Dict]: A list of dictionaries containing the normalized JSON data.
+                       Returns an empty list if the input cannot be parsed into a dict or list.
+
+        Note:
+            This method handles three cases:
+            1. Single dictionary -> wraps in list
+            2. List of dictionaries -> filters non-dict items
+            3. Invalid JSON -> returns empty list
+        """
+        response = json_repair.loads(json_str)
+        
+        if isinstance(response, dict):
+            # Wrap dict inside a list
+            return [response]
+        
+        if isinstance(response, list):
+            # Filter list elements, keep only dicts
+            filtered = [item for item in response if isinstance(item, dict)]
+            return filtered
+        
+        # If neither dict nor list, return empty list
+        return []
+
+    def map(self, data: str) -> List[Dict]:
+        """
+        Convert the input string to a list of JSON dictionaries.
+
+        This method processes the input string by attempting to parse it as JSON,
+        normalizing the response into a list of dictionaries, and handling any parsing errors.
+
+        Args:
+            data (str): The input string containing JSON data to convert
+
+        Returns:
+            List[Dict]: A list of dictionaries containing the parsed JSON data
+
+        Raises:
+            ValueError: If the JSON parsing fails or the input cannot be converted to valid JSON
         """
         try:
-            return json.loads(json_repair.repair_json(data))
+            return self.normalize_json_response(data)
         except Exception as e:
             raise ValueError(f"Failed to parse JSON: {str(e)}")
 
-    async def amap(self, data: str) -> Dict:
+    async def amap(self, data: str) -> List[Dict]:
         """
         Asynchronously convert the input string to a JSON dictionary.
 
+        This is an asynchronous wrapper around the map method that provides the same
+        functionality but in an async context. Currently, it simply calls the synchronous
+        map method as the underlying operations are not I/O bound.
+
         Args:
-            data (str): The input string to convert
+            data (str): The input string containing JSON data to convert
 
         Returns:
             Dict: The parsed JSON dictionary
+
+        Note:
+            This method currently delegates to the synchronous map method as the
+            underlying JSON parsing operations are CPU-bound rather than I/O-bound.
         """
         return self.map(data)

--- a/src/fmcore/prompt_tuner/evaluator/llm_as_a_judge_boolean/llm_as_a_judge_boolean_evaluator.py
+++ b/src/fmcore/prompt_tuner/evaluator/llm_as_a_judge_boolean/llm_as_a_judge_boolean_evaluator.py
@@ -111,12 +111,12 @@ class LLMAsJudgeBooleanEvaluator(BaseEvaluator[Dict, bool]):
                     f"[JUDGE RESPONSE]: {judge_response}\t\t ->"
                     f"[DECISION]: {decision}"
                 )
-        
+
         if not found_boolean:
             raise ValueError("None of the decisions are boolean values")
 
         return False
-        
+
     def evaluate(self, data: Dict) -> bool:
         """
         Processes the input data using the llm_as_a_judge_boolean_mapper to evaluate the context.
@@ -139,7 +139,7 @@ class LLMAsJudgeBooleanEvaluator(BaseEvaluator[Dict, bool]):
             formatted_prompt = self.text_prompt_mapper.map(data)
             llm_response = self.llm_inference_mapper.map([formatted_prompt])
             judge_responses = self.json_mapper.map(llm_response.content)
-            
+
             return self._process_judge_json_responses(
                 judge_responses=judge_responses,
                 context=data,
@@ -200,10 +200,10 @@ class LLMAsJudgeBooleanEvaluator(BaseEvaluator[Dict, bool]):
                     f"[JUDGE RESPONSE]: {judge_response}\t\t ->"
                     f"[DECISION]: {decision}"
                 )
-        
+
         if not found_boolean:
             raise ValueError("None of the decisions are boolean values")
-        
+
         return False
 
     async def aevaluate(self, data: Dict) -> bool:
@@ -228,7 +228,7 @@ class LLMAsJudgeBooleanEvaluator(BaseEvaluator[Dict, bool]):
             formatted_prompt = await self.text_prompt_mapper.amap(data)
             llm_response = await self.llm_inference_mapper.amap([formatted_prompt])
             judge_responses = await self.json_mapper.amap(llm_response.content)
-            
+
             return await self._aprocess_judge_json_responses(
                 judge_responses=judge_responses,
                 context=data,

--- a/src/fmcore/prompt_tuner/evaluator/llm_as_a_judge_boolean/llm_as_a_judge_boolean_evaluator.py
+++ b/src/fmcore/prompt_tuner/evaluator/llm_as_a_judge_boolean/llm_as_a_judge_boolean_evaluator.py
@@ -71,74 +71,179 @@ class LLMAsJudgeBooleanEvaluator(BaseEvaluator[Dict, bool]):
             criteria_checker=criteria_checker,
         )
 
+    def _process_judge_json_responses(
+        self,
+        judge_responses: list,
+        context: Dict,
+        formatted_prompt: BaseMessage,
+        llm_response: BaseMessage,
+    ) -> bool:
+        """
+        Process a list of JSON responses from judge responses and return True if any response is True.
+        Logs warnings for non-boolean responses and raises an exception if no boolean values are found.
+
+        Args:
+            judge_responses (list): List of JSON responses from the judge
+            context (Dict): Original input context
+            formatted_prompt (BaseMessage): The formatted prompt sent to the LLM
+            llm_response (BaseMessage): The raw response from the LLM
+
+        Returns:
+            bool: True if any response is True, False if all responses are False
+
+        Raises:
+            ValueError: If no boolean values are found in any response
+        """
+        found_boolean = False
+        for judge_response in judge_responses:
+            decision = self.criteria_checker.map(judge_response)
+            if isinstance(decision, bool):
+                found_boolean = True
+                if decision:
+                    return True
+            else:
+                Log.warning(
+                    "[NON-BOOLEAN RESPONSE]\t\t ->"
+                    f"[INPUT DATA]: {context}\t\t ->"
+                    f"[PROMPT]: {self.config.evaluator_params.prompt}\t\t ->"
+                    f"[FORMATTED MESSAGE]: {formatted_prompt}\t\t ->"
+                    f"[LLM RESPONSE]: {llm_response}\t\t ->"
+                    f"[JUDGE RESPONSE]: {judge_response}\t\t ->"
+                    f"[DECISION]: {decision}"
+                )
+        
+        if not found_boolean:
+            raise ValueError("None of the decisions are boolean values")
+
+        return False
+        
     def evaluate(self, data: Dict) -> bool:
         """
         Processes the input data using the llm_as_a_judge_boolean_mapper to evaluate the context.
+        Checks criteria on each element of the response list and returns True if any element evaluates to True.
+        Throws an exception if none of the responses are boolean values.
+        Logs a warning for each non-boolean response.
 
         Args:
             data (BooleanLLMJudgeInput): Input data containing context for evaluation.
 
         Returns:
-            bool: Evaluation result as a boolean decision.
+            bool: True if any element in the response list evaluates to True, False otherwise.
+
+        Raises:
+            ValueError: If none of the responses are boolean values.
         """
-        formatted_message = llm_response = json_response = decision = None
+        formatted_prompt = llm_response = judge_responses = None
 
         try:
-            formatted_message = self.text_prompt_mapper.map(data)
-            llm_response = self.llm_inference_mapper.map([formatted_message])
-            json_response = self.json_mapper.map(llm_response.content)
-            decision = self.criteria_checker.map(json_response)
-
-            if not isinstance(decision, bool):
-                raise ValueError("Decision is not a boolean value")
+            formatted_prompt = self.text_prompt_mapper.map(data)
+            llm_response = self.llm_inference_mapper.map([formatted_prompt])
+            judge_responses = self.json_mapper.map(llm_response.content)
+            
+            return self._process_judge_json_responses(
+                judge_responses=judge_responses,
+                context=data,
+                formatted_prompt=formatted_prompt,
+                llm_response=llm_response,
+            )
 
         except Exception as e:
             Log.error(
                 "[SYNC EVALUATION ERROR]\t\t ->"
                 f"[INPUT DATA]: {data}\t\t ->"
                 f"[PROMPT]: {self.config.evaluator_params.prompt}\t\t ->"
-                f"[FORMATTED MESSAGE]: {formatted_message}\t\t ->"
+                f"[FORMATTED MESSAGE]: {formatted_prompt}\t\t ->"
                 f"[LLM RESPONSE]: {llm_response}\t\t ->"
-                f"[JSON RESPONSE]: {json_response}\t\t ->"
-                f"[DECISION]: {decision}\t\t ->"
+                f"[JUDGE RESPONSES]: {judge_responses}\t\t ->"
                 f"[ERROR]: {e}"
             )
             raise
 
-        return decision
+    async def _aprocess_judge_json_responses(
+        self,
+        judge_responses: list,
+        context: Dict,
+        formatted_prompt: BaseMessage,
+        llm_response: BaseMessage,
+    ) -> bool:
+        """
+        Async version of _process_judge_json_responses.
+        Process a list of JSON responses from judge responses and return True if any response is True.
+        Logs warnings for non-boolean responses and raises an exception if no boolean values are found.
+
+        Args:
+            judge_responses (list): List of JSON responses from the judge
+            context (Dict): Original input context
+            formatted_prompt (BaseMessage): The formatted prompt sent to the LLM
+            llm_response (BaseMessage): The raw response from the LLM
+
+        Returns:
+            bool: True if any response is True, False if all responses are False
+
+        Raises:
+            ValueError: If no boolean values are found in any response
+        """
+        found_boolean = False
+        for judge_response in judge_responses:
+            decision = await self.criteria_checker.amap(judge_response)
+            if isinstance(decision, bool):
+                found_boolean = True
+                if decision:
+                    return True
+            else:
+                Log.warning(
+                    "[NON-BOOLEAN RESPONSE]\t\t ->"
+                    f"[INPUT DATA]: {context}\t\t ->"
+                    f"[PROMPT]: {self.config.evaluator_params.prompt}\t\t ->"
+                    f"[FORMATTED MESSAGE]: {formatted_prompt}\t\t ->"
+                    f"[LLM RESPONSE]: {llm_response}\t\t ->"
+                    f"[JUDGE RESPONSE]: {judge_response}\t\t ->"
+                    f"[DECISION]: {decision}"
+                )
+        
+        if not found_boolean:
+            raise ValueError("None of the decisions are boolean values")
+        
+        return False
 
     async def aevaluate(self, data: Dict) -> bool:
         """
         Asynchronous version of `evaluate` that processes the input data.
+        Checks criteria on each element of the response list and returns True if any element evaluates to True.
+        Throws an exception if none of the responses are boolean values.
+        Logs a warning for each non-boolean response.
 
         Args:
             data (BooleanLLMJudgeInput): Input data containing context for evaluation.
 
         Returns:
-            bool: Evaluation result as a boolean decision.
+            bool: True if any element in the response list evaluates to True, False otherwise.
+
+        Raises:
+            ValueError: If none of the responses are boolean values.
         """
-        formatted_message = llm_response = json_response = decision = None
+        formatted_prompt = llm_response = judge_responses = None
 
         try:
-            formatted_message = await self.text_prompt_mapper.amap(data)
-            llm_response = await self.llm_inference_mapper.amap([formatted_message])
-            json_response = await self.json_mapper.amap(llm_response.content)
-            decision = await self.criteria_checker.amap(json_response)
-
-            if not isinstance(decision, bool):
-                raise ValueError("Decision is not a boolean value")
+            formatted_prompt = await self.text_prompt_mapper.amap(data)
+            llm_response = await self.llm_inference_mapper.amap([formatted_prompt])
+            judge_responses = await self.json_mapper.amap(llm_response.content)
+            
+            return await self._aprocess_judge_json_responses(
+                judge_responses=judge_responses,
+                context=data,
+                formatted_prompt=formatted_prompt,
+                llm_response=llm_response,
+            )
 
         except Exception as e:
             Log.error(
                 "[ASYNC EVALUATION ERROR]\t\t->"
                 f"[INPUT DATA]: {data}\t\t ->"
                 f"[PROMPT]: {self.config.evaluator_params.prompt}\t\t ->"
-                f"[FORMATTED MESSAGE]: {formatted_message}\t\t ->"
+                f"[FORMATTED MESSAGE]: {formatted_prompt}\t\t ->"
                 f"[LLM RESPONSE]: {llm_response}\t\t ->"
-                f"[JSON RESPONSE]: {json_response}\t\t ->"
-                f"[DECISION]: {decision}\t\t ->"
+                f"[JUDGE RESPONSES]: {judge_responses}\t\t ->"
                 f"[ERROR]: {e}"
             )
             raise
-
-        return decision

--- a/src/fmcore/prompt_tuner/evaluator/llm_as_a_judge_boolean/llm_as_a_judge_boolean_evaluator.py
+++ b/src/fmcore/prompt_tuner/evaluator/llm_as_a_judge_boolean/llm_as_a_judge_boolean_evaluator.py
@@ -159,53 +159,6 @@ class LLMAsJudgeBooleanEvaluator(BaseEvaluator[Dict, bool]):
             )
             raise
 
-    async def _aprocess_judge_json_responses(
-        self,
-        judge_responses: list,
-        context: Dict,
-        formatted_prompt: BaseMessage,
-        llm_response: BaseMessage,
-    ) -> bool:
-        """
-        Async version of _process_judge_json_responses.
-        Process a list of JSON responses from judge responses and return True if any response is True.
-        Logs warnings for non-boolean responses and raises an exception if no boolean values are found.
-
-        Args:
-            judge_responses (list): List of JSON responses from the judge
-            context (Dict): Original input context
-            formatted_prompt (BaseMessage): The formatted prompt sent to the LLM
-            llm_response (BaseMessage): The raw response from the LLM
-
-        Returns:
-            bool: True if any response is True, False if all responses are False
-
-        Raises:
-            ValueError: If no boolean values are found in any response
-        """
-        found_boolean = False
-        for judge_response in judge_responses:
-            decision = await self.criteria_checker.amap(judge_response)
-            if isinstance(decision, bool):
-                found_boolean = True
-                if decision:
-                    return True
-            else:
-                Log.warning(
-                    "[NON-BOOLEAN RESPONSE]\t\t ->"
-                    f"[INPUT DATA]: {context}\t\t ->"
-                    f"[PROMPT]: {self.config.evaluator_params.prompt}\t\t ->"
-                    f"[FORMATTED MESSAGE]: {formatted_prompt}\t\t ->"
-                    f"[LLM RESPONSE]: {llm_response}\t\t ->"
-                    f"[JUDGE RESPONSE]: {judge_response}\t\t ->"
-                    f"[DECISION]: {decision}"
-                )
-
-        if not found_boolean:
-            raise ValueError("None of the decisions are boolean values")
-
-        return False
-
     async def aevaluate(self, data: Dict) -> bool:
         """
         Asynchronous version of `evaluate` that processes the input data.
@@ -229,7 +182,7 @@ class LLMAsJudgeBooleanEvaluator(BaseEvaluator[Dict, bool]):
             llm_response = await self.llm_inference_mapper.amap([formatted_prompt])
             judge_responses = await self.json_mapper.amap(llm_response.content)
 
-            return await self._aprocess_judge_json_responses(
+            return self._process_judge_json_responses(
                 judge_responses=judge_responses,
                 context=data,
                 formatted_prompt=formatted_prompt,


### PR DESCRIPTION
This PR enhances the JSON extraction logic to support multiple shallow JSON objects in a text stream and normalize the parsed results consistently.

Capture all shallow JSON objects ({...} without nested {}).

Use json_repair.loads() to parse possibly malformed JSON strings.

Normalize parsed results by:

Wrapping dicts as single-element lists.

Filtering non-dict elements from lists.

Returning a clean List[Dict] in all cases.

